### PR TITLE
Extend languages with Haskell

### DIFF
--- a/assets/.babelrc
+++ b/assets/.babelrc
@@ -17,7 +17,8 @@
           "java",
           "cpp",
           "go",
-          "php"
+          "php",
+          "haskell"
         ],
         // themes can be found in this directory:
         // assets/node_modules/prismjs/themes

--- a/lib/only_codes_web/templates/page_live/ranked_live.html.leex
+++ b/lib/only_codes_web/templates/page_live/ranked_live.html.leex
@@ -16,6 +16,7 @@
     "c++",
     "go",
     "php",
+    "haskell",
     ] do %>
     <option <%= if l == @currentLang, do: "selected", else: "" %> value="<%= l %>"><%= l %></option>
     <% end %>


### PR DESCRIPTION
That looks like a fun idea. Thank you for that project.

It would be awesome, if [Haskell](https://www.haskell.org) would be one of the supported languages. My guess is, it's as simple as just adding it to the list, since it is known by prism and github. Of course I'm also fine if you decide to stick to the language set you chose, and avoid extending it.