### PR TITLE
add rust support

### DIFF
--- a/assets/.babelrc
+++ b/assets/.babelrc
@@ -18,7 +18,8 @@
           "cpp",
           "go",
           "php",
-          "haskell"
+          "haskell",
+          "rust"
         ],
         // themes can be found in this directory:
         // assets/node_modules/prismjs/themes

--- a/lib/only_codes_web/templates/page_live/ranked_live.html.leex
+++ b/lib/only_codes_web/templates/page_live/ranked_live.html.leex
@@ -17,6 +17,7 @@
     "go",
     "php",
     "haskell",
+    "rust",
     ] do %>
     <option <%= if l == @currentLang, do: "selected", else: "" %> value="<%= l %>"><%= l %></option>
     <% end %>


### PR DESCRIPTION
Added Rust support #10. Inspiration: #8 

List of repos:

```
rust-lang/rust
alacritty/alacritty
sharkdp/bat
servo/servo
rust-unofficial/awesome-rust
sharkdp/fd
yewstack/yew
starship/starship
rust-lang/rustlings
firecracker-microvm/firecracker
SergioBenitez/Rocket
ogham/exa
meilisearch/MeiliSearch
tokio-rs/tokio
valeriansaliou/sonic
swc-project/swc
actix/actix-web
nushell/nushell
tikv/tikv
wasmerio/wasmer
hecrj/iced
denisidoro/navi
tauri-apps/tauri
Rigellute/spotify-tui
hyperium/hyper
dandavison/delta
BurntSushi/xsv
sharkdp/hyperfine
amethyst/amethyst
uutils/coreutils
rust-lang/cargo
diesel-rs/diesel
ruffle-rs/ruffle
RustPython/RustPython
citybound/citybound
openethereum/parity-ethereum
bevyengine/bevy
timberio/vector
actix/actix
sharkdp/hexyl
rust-lang/rust-clippy
pingcap/talent-plan
clap-rs/clap
rust-analyzer/rust-analyzer
timvisee/ffsend
Peltoche/lsd
getzola/zola
Canop/broot
Geal/nom
mimblewimble/grin
LemmyNet/lemmy
gfx-rs/gfx
maps4print/azul
tantivy-search/tantivy
XAMPPRocky/tokei
spacejam/sled
fdehau/tui-rs
cloudflare/quiche
tokio-rs/mio
seanmonstar/warp
rustwasm/wasm-bindgen
serde-rs/serde
tree-sitter/tree-sitter
PistonDevelopers/piston
bytecodealliance/lucet
seanmonstar/reqwest
rust-lang/rustfmt
graphql-rust/juniper
crossbeam-rs/crossbeam
PyO3/pyo3
launchbadge/sqlx
RustScan/RustScan
rust-lang/rls
rustwasm/wasm-pack
sharkdp/pastel
rust-embedded/rust-raspberrypi-OS-tutorials
koute/stdweb
toshi-search/Toshi
hyperium/tonic
cloudflare/boringtun
PistonDevelopers/conrod
extrawurst/gitui
tensorflow/rust
redox-os/orbtk
redox-os/tfs
chyyuu/os_kernel_lab
o2sh/onefetch
async-rs/async-std
ggez/ggez
tock/tock
rusterlium/rustler
EmbarkStudios/rust-gpu
weld-project/weld
EbTech/rust-algorithms
vulkano-rs/vulkano
Qovery/engine
microsoft/windows-rs
jmacdonald/amp
lotabout/skim
MaxBittker/sandspiel
curlpipe/ox
shadowsocks/shadowsocks-rust
ctz/rustls
NerdyPepper/dijo
habitat-sh/habitat
glium/glium
blockstack/stacks-blockchain
gluon-lang/gluon
harababurel/gcsf
MaterializeInc/materialize
nebulet/nebulet
artichoke/artichoke
pretzelhammer/rust-blog
pest-parser/pest
federico-terzi/espanso
rusoto/rusoto
gyscos/cursive
watchexec/watchexec
paritytech/polkadot
```